### PR TITLE
fix: Remove platform amd64 on postgres

### DIFF
--- a/mac.yaml
+++ b/mac.yaml
@@ -8,7 +8,7 @@ services:
     platform: "linux/amd64"
 
   evm:
-    image: loreum/hardhat
+    image: loreum/nft
     ports:
       - '8545:8545'
     platform: "linux/amd64"
@@ -22,7 +22,6 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
-    platform: "linux/amd64"
     
   graph-node:
     image: graphprotocol/graph-node


### PR DESCRIPTION
## Desc
Remove the platform value from the docker compose file for macs.